### PR TITLE
Objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+xunit.xml
+test/reports

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,6 +3,7 @@
 module.exports = function(grunt) {
   require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
   require('time-grunt')(grunt);
+  grunt.option('reporter', grunt.option('reporter') || 'xunit-file');
 
   grunt.initConfig({
     jscs: {
@@ -26,6 +27,15 @@ module.exports = function(grunt) {
         jshintrc: './.jshintrc',
         ignores: ['Gruntfile.js']
       }
+    },
+    shell: {
+      test: {
+        command: './node_modules/.bin/istanbul cover --report lcov --dir test/reports/  ./node_modules/.bin/_mocha --recursive ./test/ -- --reporter <%= grunt.option("reporter") %> <%= grunt.option("bail") && " --bail" %>',
+        options: {
+          stdout: true,
+          failOnError: true
+        }
+      }
     }
   });
 
@@ -34,5 +44,5 @@ module.exports = function(grunt) {
     'jscs'
   ]);
 
-  grunt.registerTask('test', ['lint']);
+  grunt.registerTask('test', ['lint', 'shell:test']);
 };

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Continuous deploymenting? Not sure if there is a deploy happening _right now_? U
 
 `deploy done`: Say this when you're done and then Hubot will tell the next person. Or you could say `deploy complete` or `deploy donzo`.
 
-`deploy remove <user>`: Removes a user completely from the queue. Use `remove me` to remove yourself. As my Uncle Ben said, with great power comes great responsibility. Expect angry messages if this isn\'t you remove someone else who isn\'t expecting it. Also works with `deploy kick <user>` and `deploy sayonara <user>`.
+`deploy remove <user>`: Removes a user completely from the queue. Use `remove me` to remove yourself. As my Uncle Ben said, with great power comes great responsibility. Expect angry messages if this isn't you remove someone else who isn\'t expecting it. Also works with `deploy kick <user>` and `deploy sayonara <user>`.
 
 `deploy current`: Tells you who's currently deploying. Also works with `deploy who's deploying` and `deploy who's at bat`.
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ Continuous deploymenting? Not sure if there is a deploy happening _right now_? U
 
 `deploy done`: Say this when you're done and then Hubot will tell the next person. Or you could say `deploy complete` or `deploy donzo`.
 
-`deploy forget me`: Removes you from the queue. If you're on there more than once, then just removes your next turn. If you're on there more than once, you might think about slowing down and deploying a little less continuously. Or you could say `deploy forget it` or `deploy nevermind`
-
-`deploy remove <user>`: Removes a user completely from the queue. As my Uncle Ben said, with great power comes great responsibility. Expect angry messages if this isn't what you meant to do. Also works with `deploy kick <user>` and `deploy sayonara <user>`.
+`deploy remove <user>`: Removes a user completely from the queue. Use `remove me` to remove yourself. As my Uncle Ben said, with great power comes great responsibility. Expect angry messages if this isn\'t you remove someone else who isn\'t expecting it. Also works with `deploy kick <user>` and `deploy sayonara <user>`.
 
 `deploy current`: Tells you who's currently deploying. Also works with `deploy who's deploying` and `deploy who's at bat`.
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ module.exports = function(robot) {
   robot.respond(/deploy help/i, help);
   robot.respond(/deploy (me|moi)?(.*)/i, queueUser);
   robot.respond(/deploy (done|complete|donzo)/i, dequeueUser);
-  robot.respond(/deploy (forget (it|me)|nevermind)/i, forgetMe);
   robot.respond(/deploy (current|who\'s (deploying|at bat))/i, whosDeploying);
   robot.respond(/deploy (next|who\'s (next|on first|on deck))/i, whosNext);
   robot.respond(/deploy (remove|kick|sayonara) (.*)/i, removeUser);
@@ -32,8 +31,7 @@ module.exports = function(robot) {
     res.send(
       '`deploy me`: Add yourself to the deploy queue. Hubot give you a heads up when it\'s your turn\n' +
       '`deploy done`: Say this when you\'re done and then Hubot will tell the next person. Or you could say `deploy complete` or `deploy donzo`.\n' +
-      '`deploy forget me`: Removes you from the queue. If you\'re on there more than once, then just removes your next turn. If you\'re on there more than once, you might think about slowing down and deploying a little less continuously. Or you could say `deploy forget it` or `deploy nevermind`.\n' +
-      '`deploy remove _user_`: Removes a user completely from the queue. As my Uncle Ben said, with great power comes great responsibility. Expect angry messages if this isn\'t what you meant to do. Also works with `deploy kick _user_` and `deploy sayonara _user_`.\n' +
+      '`deploy remove _user_`: Removes a user completely from the queue. Use `remove me` to remove yourself. As my Uncle Ben said, with great power comes great responsibility. Expect angry messages if this isn\'t you remove someone else who isn\'t expecting it. Also works with `deploy kick _user_` and `deploy sayonara _user_`.\n' +
       '`deploy current`: Tells you who\'s currently deploying. Also works with `deploy who\'s deploying` and `deploy who\'s at bat`.\n' +
       '`deploy next`: Sneak peek at the next person in line. Do this if the anticipation is killing you. Also works with `deploy who\'s next` and `deploy who\'s on first`.\n' +
       '`deploy list`: Lists the queue. Use wisely, it\'s going to ping everyone :)\n' +
@@ -162,6 +160,11 @@ module.exports = function(robot) {
   function removeUser(res) {
     var user = res.match[1]
       , notifyNextUser = queue.isCurrent(user);
+
+    if(user === 'me') {
+      forgetMe(res);
+      return;
+    }
 
     queue.removeAll(user);
 

--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ module.exports = function(robot) {
     var user = res.match[1]
       , notifyNextUser = queue.isCurrent(user);
 
-    if(user === 'me') {
+    if (user === 'me') {
       forgetMe(res);
       return;
     }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -32,8 +32,7 @@ module.exports.isEmpty = function() {
  * @returns {Number|boolean}
  */
 module.exports.isCurrent = function(item) {
-  // TODO handle objects
-  return db.queue.length && db.queue[0].name === item;
+  return _.findIndex(db.queue, item) === 0;
 };
 
 /**
@@ -42,8 +41,7 @@ module.exports.isCurrent = function(item) {
  * @returns {Number|boolean}
  */
 module.exports.isNext = function(item) {
-  // TODO handle objects
-  return db.queue.length && db.queue[1].name === item;
+  return _.findIndex(db.queue, item) === 1;
 };
 
 /**
@@ -52,8 +50,7 @@ module.exports.isNext = function(item) {
  * @returns {boolean}
  */
 module.exports.contains = function(item) {
-  // TODO handle objects
-  return _.findWhere(db.queue, {name: item}) !== undefined;
+  return _.find(db.queue, item) !== undefined;
 };
 
 /**
@@ -105,7 +102,6 @@ module.exports.advance = function() {
  */
 module.exports.remove = function(item) {
   var start = db.queue.length;
-  // TODO handle objects
-  _.pull(db.queue, item);
+  _.pullAt(db.queue, _.findIndex(db.queue, item));
   return start - db.queue.length;
 };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,60 +1,111 @@
 var _ = require('lodash')
-  , data;
+  , db;
 
-module.exports.init = function(d) {
-  data = d;
-  data.deployQueue = data.deployQueue || [];
+/**
+ * Initializes the queue
+ * @param database
+ */
+module.exports.init = function(database) {
+  db = database;
+  db.queue = db.queue || [];
 };
 
+/**
+ * Returns the queue data, used for debugging only
+ * @returns {*|Array}
+ */
 module.exports.get = function() {
-  return data.deployQueue;
+  return db.queue;
 };
 
+/**
+ * Is the queue empty?
+ * @returns {boolean}
+ */
 module.exports.isEmpty = function() {
-  return data.deployQueue.length === 0;
+  return db.queue.length === 0;
 };
 
+/**
+ * Is this item at the head of the queue
+ * @param item
+ * @returns {Number|boolean}
+ */
 module.exports.isCurrent = function(item) {
-  return data.deployQueue[0] === item;
+  // TODO handle objects
+  return db.queue.length && db.queue[0].name === item;
 };
 
+/**
+ * Is this item immediately following the head
+ * @param item
+ * @returns {Number|boolean}
+ */
 module.exports.isNext = function(item) {
-  return data.deployQueue[1] === item;
+  // TODO handle objects
+  return db.queue.length && db.queue[1].name === item;
 };
 
+/**
+ * Does the queue contain this item?
+ * @param item
+ * @returns {boolean}
+ */
 module.exports.contains = function(item) {
-  return _.contains(data.deployQueue, item);
+  // TODO handle objects
+  return _.findWhere(db.queue, {name: item}) !== undefined;
 };
 
+/**
+ * The length of the queue
+ * @returns {Number}
+ */
 module.exports.length = function() {
-  return data.deployQueue.length;
+  return db.queue.length;
 };
 
+/**
+ * Adds an item to the queue
+ * @param item
+ * @returns {Number}
+ */
 module.exports.push = function(item) {
-  return data.deployQueue.push(item);
+  return db.queue.push(item);
 };
 
+/**
+ * Returns the head of the queue
+ * @returns {*}
+ */
 module.exports.current = function() {
-  return data.deployQueue[0];
+  return db.queue[0];
 };
 
+/**
+ * Returns the item after the head
+ * @returns {*}
+ */
 module.exports.next = function() {
-  return data.deployQueue[1];
+  return db.queue[1];
 };
 
+/**
+ * Removes first element from the queue
+ * @returns {*} Returns the new head of the queue
+ */
 module.exports.advance = function() {
-  data.deployQueue.shift();
-  return data.deployQueue[0];
+  db.queue.shift();
+  return db.queue[0];
 };
 
-module.exports.removeOne = function(item) {
-  var start = data.deployQueue.length;
-  _.pullAt(data.deployQueue, _.indexOf(data.deployQueue, item));
-  return start - data.deployQueue.length;
-};
-
-module.exports.removeAll = function(item) {
-  var start = data.deployQueue.length;
-  _.pull(data.deployQueue, item);
-  return start - data.deployQueue.length;
+/**
+ * Removes all instances of the item from the queue.
+ * @param item
+ * @returns {number} Returns the number or items removed
+ */
+module.exports.remove = function(item) {
+  var start = db.queue.length;
+  // TODO handle objects
+  _.pull(db.queue, item);
+  return start - db.queue.length;
 };

--- a/package.json
+++ b/package.json
@@ -17,10 +17,17 @@
     "lodash": "^3.10.1"
   },
   "devDependencies": {
+    "chai": "^3.4.0",
+    "growl": "^1.8.1",
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^0.11.3",
     "grunt-jscs": "^2.3.0",
+    "grunt-shell": "^1.1.2",
+    "istanbul": "^0.4.0",
     "matchdep": "^1.0.0",
-    "time-grunt": "^1.2.2"
+    "mocha": "^2.3.3",
+    "sinon": "^1.17.2",
+    "time-grunt": "^1.2.2",
+    "xunit-file": "0.0.9"
   }
 }

--- a/test/queue.spec.js
+++ b/test/queue.spec.js
@@ -1,0 +1,115 @@
+var chai = require('chai')
+  , expect = chai.expect;
+
+describe('Queue', function() {
+  var queue
+    , brain;
+
+  beforeEach(function() {
+    queue = require('../lib/queue');
+    brain = {};
+    queue.init(brain);
+  });
+
+  it('should create a queue object', function() {
+    expect(brain.queue).to.be.an.array;
+    expect(brain.queue).to.have.length(0);
+  });
+
+  it('should return the queue', function() {
+    expect(queue.get()).to.equal(brain.queue);
+  });
+
+  it('should test that the queue is empty', function() {
+    expect(queue.isEmpty()).to.be.true;
+    queue.push({name: 'walterwhite', othername: 'heisenberg'});
+    expect(queue.isEmpty()).to.be.false;
+  });
+
+  it('should allow items to be pushed onto the queue', function() {
+    var item = {name: 'walterwhite', othername: 'heisenberg'};
+    expect(brain.queue).to.have.length(0);
+    queue.push(item);
+    expect(brain.queue).to.have.length(1);
+  });
+
+  it('should test if an item is at the head of the queue', function() {
+    queue.push({name: 'walterwhite', othername: 'heisenberg'});
+    expect(queue.isCurrent({name: 'walterwhite'})).to.be.true;
+    expect(queue.isCurrent({name: 'jesse'})).to.be.false;
+  });
+
+  it('should test if an item is next', function() {
+    queue.push({name: 'walterwhite', othername: 'heisenberg'});
+    queue.push({name: 'jesse', othername: 'capncook'});
+    expect(queue.isNext({name: 'walterwhite'})).to.be.false;
+    expect(queue.isNext({name: 'jesse'})).to.be.true;
+  });
+
+  it('should test if an item contained in the queue', function() {
+    queue.push({name: 'walterwhite', othername: 'heisenberg'});
+    queue.push({name: 'jesse', othername: 'capncook'});
+    expect(queue.contains({name: 'walterwhite'})).to.be.true;
+    expect(queue.contains({name: 'jesse'})).to.be.true;
+    expect(queue.contains({name: 'tortuga'})).to.be.false;
+  });
+
+  it('should return the length of the queue', function() {
+    expect(queue.length()).to.equal(0);
+    queue.push({name: 'walterwhite', othername: 'heisenberg'});
+    queue.push({name: 'jesse', othername: 'capncook'});
+    expect(queue.length()).to.equal(2);
+  });
+
+  it('should get the head of the queue', function() {
+    var item = {name: 'walterwhite', othername: 'heisenberg'};
+    queue.push(item);
+    queue.push({name: 'jesse', othername: 'capncook'});
+    expect(queue.current()).to.equal(item);
+  });
+
+  it('should get the next item in the queue', function() {
+    var item = {name: 'jesse', othername: 'capncook'};
+    queue.push({name: 'walterwhite', othername: 'heisenberg'});
+    queue.push(item);
+    expect(queue.next()).to.equal(item);
+  });
+
+  it('should advance the queue', function() {
+    var walter = {name: 'walterwhite', othername: 'heisenberg'}
+      , jesse = {name: 'jesse', othername: 'capncook'};
+
+    queue.push(walter);
+    queue.push(jesse);
+
+    expect(queue.advance()).to.equal(jesse);
+    expect(queue.length()).to.equal(1);
+
+    expect(queue.advance()).to.be.undefined;
+    expect(queue.length()).to.equal(0);
+
+    //advance an empty queue
+    expect(queue.advance()).to.be.undefined;
+    expect(queue.length()).to.equal(0);
+  });
+
+  it('should remove items from the queue', function() {
+    var walter = {name: 'walterwhite', othername: 'heisenberg'}
+      , jesse = {name: 'jesse', othername: 'capncook'};
+
+    queue.push(jesse);
+    queue.push(walter);
+
+    expect(queue.length()).to.equal(2);
+    queue.remove({name: 'jesse'});
+    expect(queue.length()).to.equal(1);
+    expect(queue.contains({name: 'jesse'})).to.be.false;
+
+    queue.push(jesse);
+
+    expect(queue.length()).to.equal(2);
+    queue.remove({name: 'jesse'});
+    expect(queue.length()).to.equal(1);
+    expect(queue.contains({name: 'jesse'})).to.be.false;
+  });
+});


### PR DESCRIPTION
I wanna have the queue store objects. Queries on the queue (like `contains()`) will accept a lodash `find` callback (either a function, `pluck`, or `where` style). Any item returned from the queue will return the exact object that was pushed on.

I added a capture group to `deploy me` to store meta data, right now this is only displayed on `deploy next`. 

I also added unit tests for the queue lib.
