### PR TITLE
Allow people to enter themselves into the queue multiple times

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,9 @@ module.exports = function(robot) {
 
   robot.respond(/deploy help/i, help);
   robot.respond(/deploy (add)(.*)?/i, queueUser);
-  robot.respond(/deploy (done|complete|donzo)/i, dequeueUser);
-  robot.respond(/deploy (current|who\'s (deploying|at bat))/i, whosDeploying);
-  robot.respond(/deploy (next|who\'s (next|on first|on deck))/i, whosNext);
+  robot.respond(/deploy (done|complete)/i, dequeueUser);
+  robot.respond(/deploy (current|who\'s deploying)/i, whosDeploying);
+  robot.respond(/deploy (next|who\'s next)/i, whosNext);
   robot.respond(/deploy (remove|kick) (.*)/i, removeUser);
   robot.respond(/deploy (list)/i, listQueue);
   robot.respond(/deploy (dump|debug)/i, queueDump);
@@ -27,14 +27,12 @@ module.exports = function(robot) {
    */
   function help(res) {
     res.send(
-      '`deploy add _metadata_`: Add yourself to the deploy queue. Hubot give you a heads up when it\'s your turn. Anything after `add` will be included in messages about what you\'re deploying, if you\'re into that sort of thing. Something like `hubot deploy add my_api`.\n' +
-      '`deploy done`: Say this when you\'re done and then Hubot will tell the next person. Or you could say `deploy complete` or `deploy donzo`.\n' +
-      '`deploy remove _user_`: Removes a user completely from the queue. Use `remove me` to remove yourself. As my Uncle Ben said, with great power comes great responsibility. Expect angry messages if this isn\'t you remove someone else who isn\'t expecting it. Also works with `deploy kick _user_`.\n' +
-      '`deploy current`: Tells you who\'s currently deploying. Also works with `deploy who\'s deploying` and `deploy who\'s at bat`.\n' +
-      '`deploy next`: Sneak peek at the next person in line. Do this if the anticipation is killing you. Also works with `deploy who\'s next` and `deploy who\'s on first`.\n' +
-      '`deploy list`: Lists the queue. Use wisely, it\'s going to ping everyone :)\n' +
-      '`deploy debug`: Kinda like `deploy list`, but for nerds.\n' +
-      '`deploy help`: This thing.'
+      '`deploy add _metadata_`: Add yourself to the deploy queue. Hubot give you a heads up when it\'s your turn. Anything after `add` will be included in messages about what you\'re deploying. Something like `hubot deploy add my_api`.\n' +
+      '`deploy done`: Say this when you\'re done and then Hubot will tell the next person. Or you could say `deploy complete`.\n' +
+      '`deploy remove _user_`: Removes a user completely from the queue. Use `remove me` to remove yourself. Also works with `deploy kick _user_`.\n' +
+      '`deploy next`: Sneak peek at the next person in line. Also works with `deploy who\'s next` and `deploy who\'s on first`.\n' +
+      '`deploy list`: Lists the queue.\n' +
+      '`deploy debug`: Kinda like `deploy list`.\n'
     );
   }
 
@@ -64,7 +62,7 @@ module.exports = function(robot) {
       return;
     }
 
-    res.reply('Cool, There\'s ' + (length - 1) + ' person(s) ahead of you. I\'ll let you know when you\'re up.');
+    res.reply('There\'s ' + (length - 1) + ' person(s) ahead of you. I\'ll let you know when you\'re up.');
   }
 
   /**
@@ -102,7 +100,7 @@ module.exports = function(robot) {
       , user = {name: name};
 
     if (queue.isEmpty()) {
-      res.send('Nobodyz!');
+      res.send('Nobody!');
     } else if (queue.isCurrent(user)) {
       res.reply('It\'s you. _You\'re_ deploying. Right now.');
     } else {
@@ -123,11 +121,11 @@ module.exports = function(robot) {
       , next = queue.next();
 
     if (!next) {
-      res.send('Nobodyz!');
+      res.send('Nobody!');
     } else if (queue.isNext({name: user})) {
       res.reply('You\'re up next! Get ready!');
     } else {
-      res.send(queue.next().name + ' is on deck.');
+      res.send(queue.next().name + ' is next.');
     }
   }
 
@@ -184,7 +182,7 @@ module.exports = function(robot) {
    */
   function listQueue(res) {
     if (queue.isEmpty()) {
-      res.send('Nobody! Like this: []');
+      res.send('Nobody!');
     } else {
       res.send('Here\'s who\'s in the queue: ' + _.pluck(queue.get(), 'name').join(', ') + '.');
     }

--- a/index.js
+++ b/index.js
@@ -54,15 +54,11 @@ module.exports = function(robot) {
 
     if (length === 0) {
       res.reply('Go for it!');
-      return;
-    }
-
-    if (length === 1) {
+    } else if (length === 1) {
       res.reply('Alrighty, you\'re up after current deployer.');
-      return;
+    } else {
+      res.reply('There\'s ' + length + ' people ahead of you. I\'ll let you know when you\'re up.');
     }
-
-    res.reply('There\'s ' + (length - 1) + ' person(s) ahead of you. I\'ll let you know when you\'re up.');
   }
 
   /**
@@ -169,11 +165,10 @@ module.exports = function(robot) {
       res.reply('No sweat! You weren\'t even in the queue :)');
     } else if (queue.isCurrent(user)) {
       res.reply('You\'re deploying right now! Did you mean `deploy done`?');
-      return;
+    } else {
+      queue.remove(user);
+      res.reply('Alright, I took you out of the queue. Come back soon!');
     }
-
-    queue.remove(user);
-    res.reply('Alright, I took you out of the queue. Come back soon!');
   }
 
   /**
@@ -204,4 +199,3 @@ module.exports = function(robot) {
     robot.messageRoom(user.name, 'Hey, your turn to deploy!');
   }
 };
-

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ var queue = require('./lib/queue')
 
 module.exports = function(robot) {
   robot.brain.on('loaded', function() {
-    robot.brain.deploy = robot.brain.deploy || {};
-    queue.init(robot.brain.deploy);
+    robot.brain.data.deploy = robot.brain.data.deploy || {};
+    queue.init(robot.brain.data.deploy);
   });
 
   robot.respond(/deploy help/i, help);
@@ -49,7 +49,7 @@ module.exports = function(robot) {
       , metadata = (res.match[2] || '').trim();
 
     if (queue.contains({name: user})) {
-      res.reply('Whoa, hold you\'re horses! You\'re already in the queue once. Maybe give someone else a chance first?');
+      res.reply('Sorry but you can only have one position in the queue at a time. Please complete your first deploy before requeueing yourself.');
       return;
     }
 
@@ -61,7 +61,7 @@ module.exports = function(robot) {
     }
 
     if (length === 1) {
-      res.reply('Alrighty, you\'re up next!');
+      res.reply('Alrighty, you\'re up after current deployer.');
       return;
     }
 
@@ -185,7 +185,7 @@ module.exports = function(robot) {
    */
   function listQueue(res) {
     if (queue.isEmpty()) {
-      res.send('Nobodyz! Like this: []');
+      res.send('Nobody! Like this: []');
     } else {
       res.send('Here\'s who\'s in the queue: ' + _.pluck(queue.get(), 'name').join(', ') + '.');
     }
@@ -204,7 +204,7 @@ module.exports = function(robot) {
    * @param user
    */
   function notifyUser(user) {
-    robot.messageRoom(user.name, 'Hey, you\'re turn to deploy!');
+    robot.messageRoom(user.name, 'Hey, your turn to deploy!');
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -4,8 +4,7 @@ var queue = require('./lib/queue')
 
 module.exports = function(robot) {
   robot.brain.on('loaded', function() {
-    robot.brain.data.deploy = robot.brain.data.deploy || {};
-    queue.init(robot.brain.data.deploy);
+    queue.init(robot);
   });
 
   robot.respond(/deploy help/i, help);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -7,7 +7,7 @@ var _ = require('lodash')
  * @param database
  */
 module.exports.init = function(r) {
-  brain = robot.brain;
+  brain = r.brain;
   db = brain.get('db') || { queue: [] };
 };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,13 +1,14 @@
 var _ = require('lodash')
+  , brain
   , db;
 
 /**
  * Initializes the queue
  * @param database
  */
-module.exports.init = function(database) {
-  db = database;
-  db.queue = db.queue || [];
+module.exports.init = function(r) {
+  brain = robot.brain;
+  db = brain.get('db') || { queue: [] };
 };
 
 /**
@@ -67,7 +68,9 @@ module.exports.length = function() {
  * @returns {Number}
  */
 module.exports.push = function(item) {
-  return db.queue.push(item);
+  var result = db.queue.push(item);
+  brain.set('db', db);
+  return result;
 };
 
 /**
@@ -92,6 +95,7 @@ module.exports.next = function() {
  */
 module.exports.advance = function() {
   db.queue.shift();
+  brain.set('db', db);
   return db.queue[0];
 };
 
@@ -103,5 +107,6 @@ module.exports.advance = function() {
 module.exports.remove = function(item) {
   var start = db.queue.length;
   _.pullAt(db.queue, _.findIndex(db.queue, item));
+  brain.set('db', db);
   return start - db.queue.length;
 };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -106,7 +106,10 @@ module.exports.advance = function() {
  */
 module.exports.remove = function(item) {
   var start = db.queue.length;
-  _.pullAt(db.queue, _.findIndex(db.queue, item));
+  _.remove(db.queue, function(entry) {
+    return _.isEqual(entry, item);
+  });
+
   brain.set('db', db);
   return start - db.queue.length;
 };


### PR DESCRIPTION
This in theory allows you to add yourself multiple times to the deploy queue.

## Behavior
- `remove|kick` now drop _all_ instances of you in the queue.
- Some new messages for situations that didn't previously exist (deploy done but you're up next, added to the deploy queue but you're already deploying, etc)
- Who's deploying might return the same name several times

I am not certain that all or some of this isn't broken